### PR TITLE
Download readme and xml for patches

### DIFF
--- a/Shell/getMOSPatch.sh
+++ b/Shell/getMOSPatch.sh
@@ -63,7 +63,7 @@ rm $TMP2 $TMP1 $TMP3 >/dev/null 2>&1
 set -e
 
 # If we run the script the first time we need to collect Language and Platform settings.
-# This part also executes if reset=yes of file is empty.
+# This part also executes if reset=yes or if file is empty.
 # This part fetches the simple search form from mos and parses all Platform and Language codes
 if [ ! -f $CFG ] || [ "$p_reset" == "yes" ] || [ "`file -b $CFG`"  == "empty" ]; then
   echo; echo Getting the Platform/Language list

--- a/Shell/getMOSPatch.sh
+++ b/Shell/getMOSPatch.sh
@@ -121,12 +121,21 @@ for URL in $(cat $TMP3)
 do
   fname=`echo ${URL} | awk -F"=" '{print $NF;}' | sed "s/[?&]//g"`
   fname_=${fname%.zip}
+
+  echo
   echo "Downloading file $fname ..."
-##  wget --secure-protocol=TLSv1 --no-check-certificate --load-cookies=$COOK "$URL" -O $fname -q
-  curl -b $COOK -c $COOK --tlsv1 --insecure --output $fname -L "$URL"
-  echo "$fname completed with status: $?"
+  if [ $p_skip ] && [ -f $fname ]; then
+    ls -l $fname
+    echo "file $fname found,  skipping"
+  else
+    ##  wget --secure-protocol=TLSv1 --no-check-certificate --load-cookies=$COOK "$URL" -O $fname -q
+    curl -b $COOK -c $COOK --tlsv1 --insecure --output $fname -L "$URL" ;
+    echo "$fname completed with status: $?"
+  fi
 
 ## download readme and rename to html or txt
+  echo
+  echo "Downloading readme file ..."
   curl -b $COOK -c $COOK --tlsv1 --insecure --output $fname_.readme -L "https://updates.oracle.com/Orion/Services/download?type=readme&bugfix_name=$pp_patch"
   if [ -f $fname_.readme ]; then
     if [ "`file -b $fname_.readme`" == "HTML document text" ]; then
@@ -137,6 +146,8 @@ do
   fi
 
 ## download xml
+  echo
+  echo "Downloading xml file ..."
   curl -b $COOK -c $COOK --tlsv1 --insecure --output ${fname%.zip}.xml -L "https://updates.oracle.com/Orion/Services/search?bug=$pp_patch"
 
 done

--- a/Shell/getMOSPatch.sh
+++ b/Shell/getMOSPatch.sh
@@ -120,10 +120,26 @@ echo "Downloading the patches:"
 for URL in $(cat $TMP3)
 do
   fname=`echo ${URL} | awk -F"=" '{print $NF;}' | sed "s/[?&]//g"`
+  fname_=${fname%.zip}
   echo "Downloading file $fname ..."
 ##  wget --secure-protocol=TLSv1 --no-check-certificate --load-cookies=$COOK "$URL" -O $fname -q
   curl -b $COOK -c $COOK --tlsv1 --insecure --output $fname -L "$URL"
   echo "$fname completed with status: $?"
+
+## download readme and rename to html or txt
+  curl -b $COOK -c $COOK --tlsv1 --insecure --output $fname_.readme -L "https://updates.oracle.com/Orion/Services/download?type=readme&bugfix_name=$pp_patch"
+  if [ -f $fname_.readme ]; then
+    if [ "`file -b $fname_.readme`" == "HTML document text" ]; then
+      mv $fname_.readme $fname_.html
+    else
+      mv $fname_.readme $fname_.txt
+    fi
+  fi
+
+## download xml
+  curl -b $COOK -c $COOK --tlsv1 --insecure --output ${fname%.zip}.xml -L "https://updates.oracle.com/Orion/Services/search?bug=$pp_patch"
+
 done
+
 rm $TMP3
 rm $COOK >/dev/null 2>&1


### PR DESCRIPTION
3 changes.
1. introduce skip=

if defined and file exits, then skip the file to avoid re-download.

2.

Download readme and xml metadata of the patch.
Evaluate if readme is html, and rename to .html, otherwise assume is text and name it as .txt

example files generated:

``` shell
p19491900_R12.ADO.C_R12_GENERIC.html
p19491900_R12.ADO.C_R12_GENERIC.xml
p19491900_R12.ADO.C_R12_GENERIC.zip
p6880880_101000_Linux-x86-64.txt
p6880880_101000_Linux-x86-64.xml
p6880880_101000_Linux-x86-64.zip
```

So on the server where patches are left, the readme became available:

![image](https://cloud.githubusercontent.com/assets/1255709/4907390/94b258f0-6461-11e4-9d66-409aed846f84.png)

The XML files I do believe can be then used into Enterprise Manager, not tested yet, but they download fine.

3 add destination= so the script can be run from other script or cron and will leave all the download patches in the desired folder
