### PR TITLE
use curl -R, add destination=, readme=, xml=

### DIFF
--- a/Shell/getMOSPatch.sh
+++ b/Shell/getMOSPatch.sh
@@ -37,6 +37,7 @@ fi
 # change into p_destination if defined, so we can run this from crontab or from other script
 if [ $p_destination ]; then
   echo "changing directory to $p_destination"
+  [ -d $p_destination ] || mkdir -p $p_destination
   pushd $p_destination >/dev/null 2>&1
   UNPUSHD="$?"
 fi

--- a/Shell/getMOSPatch.sh
+++ b/Shell/getMOSPatch.sh
@@ -10,15 +10,6 @@
 # exit on the first error
 set -e
 
-# Setting some variables for the files I'll operati with
-PREF=`basename $0`
-CD=`dirname $0`
-CFG=${CD}/.${PREF}.cfg
-TMP1=${CD}/.${PREF}.tmp1
-TMP2=${CD}/.${PREF}.tmp2
-TMP3=${CD}/.${PREF}.tmp3
-COOK=${CD}/.${PREF}.cookies
-
 # Processing the arguments by setting the respective variables
 # all arguments are passed to the shell scripts in form argname=argvalue
 # This command sets the following variables for each argument: p_argname=argvalue
@@ -41,6 +32,15 @@ if [ $p_destination ]; then
   pushd $p_destination >/dev/null 2>&1
   UNPUSHD="$?"
 fi
+
+# Setting some variables for the files I'll operati with
+PREF=`basename $0`
+CD=`dirname $0`
+CFG=${CD}/.${PREF}.cfg
+TMP1=${CD}/.${PREF}.tmp1
+TMP2=${CD}/.${PREF}.tmp2
+TMP3=${CD}/.${PREF}.tmp3
+COOK=${CD}/.${PREF}.cookies
 
 # Reading the MOS user credentials. Set environment variables mosUser and mosPass if you want to skip this.
 [[ $mosUser ]] || read -p "Oracle Support Userid: " mosUser;
@@ -183,9 +183,9 @@ if [ ! -z ${p_patch} ] ; then
   rm $TMP3 >/dev/null 2>&1
 fi
 
+rm $COOK >/dev/null 2>&1
+
 #leave the pushd if defined, running popd
 if [ $UNPUSHD ]; then
   popd >/dev/null 2>&1
 fi
-
-rm $COOK >/dev/null 2>&1

--- a/Shell/getMOSPatch.sh
+++ b/Shell/getMOSPatch.sh
@@ -160,14 +160,9 @@ if [ ! -z ${p_patch} ] ; then
     fname_=${fname%.zip}
     ## download readme and rename to html or txt
     if [ $p_readme ] && [ $p_readme == "yes" ]; then
-      if [ -f $fname_.txt ]; then
-        current="$fname_.txt"
-      else
-        current="$fname_.html"
-      fi
       echo
       echo "Downloading readme file ..."
-      curl -R -b $COOK -c $COOK --tlsv1 --insecure -z $current --output $fname_.readme -L "https://updates.oracle.com/Orion/Services/download?type=readme&bugfix_name=$pp_patch"
+      curl -R -b $COOK -c $COOK --tlsv1 --insecure --output $fname_.readme -L "https://updates.oracle.com/Orion/Services/download?type=readme&bugfix_name=$pp_patch"
       if [ -f $fname_.readme ]; then
         if [ "`file -b $fname_.readme`" == "HTML document text" ]; then
           mv $fname_.readme $fname_.html
@@ -181,7 +176,7 @@ if [ ! -z ${p_patch} ] ; then
     if [ $p_xml ] && [ $p_xml == "yes" ]; then
       echo
       echo "Downloading xml file ..."
-      curl -R -b $COOK -c $COOK --tlsv1 --insecure -z $fname_.xml --output $fname_.xml -L "https://updates.oracle.com/Orion/Services/search?bug=$pp_patch"
+      curl -R -b $COOK -c $COOK --tlsv1 --insecure --output $fname_.xml -L "https://updates.oracle.com/Orion/Services/search?bug=$pp_patch"
     fi
     
   done


### PR DESCRIPTION
Hello, this Pull Request add the following options

use curl -R to keep source timestamp. This make the files to have timestamp like the source files:

``` shell
-rw-r--r--  1 502 80 26365981 Jun  2  2012 p6880880_101000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80 27412455 Jun  1  2012 p6880880_102000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80 54484029 Nov 29 08:18 p6880880_111000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80 33020933 Dec 18  2013 p6880880_112000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80 52216311 Jan 14 12:55 p6880880_121010_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80  3893771 Jul  3  2013 p6880880_131000_Generic.zip                                                                                                                                        
-rw-r--r--  1 502 80  3922065 Jul 17  2014 p6880880_132000_Generic.zip     
```

this allow to do a check if the file exist, using in curl `-z <file>` will check if the file need to be downloaded again or not.

on a first run, for opatch, all version it takes:

``` shell
real    3m24.565s                                                                                                                                                                                             
user    0m0.868s                                                                                                                                                                                              
sys     0m5.296s   
```

on a second run, no changes found:

``` shell
real    1m49.462s                                                                                                                                                                                             
user    0m2.082s                                                                                                                                                                                              
sys     0m1.046s 
```

This is important, since Oracle release OPatch with same patch names, and this check is based on source/destination difference.

This also allow skip patches that already exist.

other option added are:

destination=

using pushd and popd, create the directory, change into $p_destination, and leave the files in that path. usefulf for remote scripts.

sample:

``` shell
# ls -al /var/www/html/oracle_patch/                                                                                                                                                   
total 212368                                                                                                                                                                                                                                                                                                                                      
-rw-r--r--  1 502 80     2913 Feb  3 15:45 p6880880_101000_Linux-x86-64.txt                                                                                                                                   
-rw-r--r--  1 502 80  2296105 Feb  3 15:45 p6880880_101000_Linux-x86-64.xml                                                                                                                                   
-rw-r--r--  1 502 80 26365981 Jun  2  2012 p6880880_101000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80     2913 Feb  3 15:45 p6880880_102000_Linux-x86-64.txt                                                                                                                                   
-rw-r--r--  1 502 80  2296105 Feb  3 15:45 p6880880_102000_Linux-x86-64.xml                                                                                                                                   
-rw-r--r--  1 502 80 27412455 Jun  1  2012 p6880880_102000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80     2913 Feb  3 15:43 p6880880_111000_Linux-x86-64.txt                                                                                                                                   
-rw-r--r--  1 502 80  2296105 Feb  3 15:43 p6880880_111000_Linux-x86-64.xml                                                                                                                                   
-rw-r--r--  1 502 80 54484029 Nov 29 08:18 p6880880_111000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80     2913 Feb  3 15:44 p6880880_112000_Linux-x86-64.txt                                                                                                                                   
-rw-r--r--  1 502 80  2296105 Feb  3 15:44 p6880880_112000_Linux-x86-64.xml                                                                                                                                   
-rw-r--r--  1 502 80 33020933 Dec 18  2013 p6880880_112000_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80     2913 Feb  3 15:50 p6880880_121010_Linux-x86-64.txt                                                                                                                                   
-rw-r--r--  1 502 80  2296105 Feb  3 15:51 p6880880_121010_Linux-x86-64.xml                                                                                                                                   
-rw-r--r--  1 502 80 52216311 Jan 14 12:55 p6880880_121010_Linux-x86-64.zip                                                                                                                                   
-rw-r--r--  1 502 80     2913 Feb  3 15:44 p6880880_131000_Generic.txt                                                                                                                                        
-rw-r--r--  1 502 80  2296105 Feb  3 15:44 p6880880_131000_Generic.xml                                                                                                                                        
-rw-r--r--  1 502 80  3893771 Jul  3  2013 p6880880_131000_Generic.zip                                                                                                                                        
-rw-r--r--  1 502 80     2913 Feb  3 15:43 p6880880_132000_Generic.txt                                                                                                                                        
-rw-r--r--  1 502 80  2296105 Feb  3 15:44 p6880880_132000_Generic.xml                                                                                                                                        
-rw-r--r--  1 502 80  3922065 Jul 17  2014 p6880880_132000_Generic.zip                                                                                                                                        
#  
```

xml=yes
will download the xml file associated to the patch

sample:
p20132462_121020_Linux-x86-64.xml
![image](https://cloud.githubusercontent.com/assets/1255709/6013652/9e3d26dc-abbc-11e4-906e-1a6742a78836.png)

readme=yes
will download the readme of the file associated to the patch.

sample:
p20132462_121020_Linux-x86-64.html
![image](https://cloud.githubusercontent.com/assets/1255709/6013662/b95cd692-abbc-11e4-8c78-37e8ccd32683.png)
