### PR TITLE
Change Date format to  ISO 8601 

### DIFF
--- a/SQL/AWR/awr_sqlid_perf_trend.sql
+++ b/SQL/AWR/awr_sqlid_perf_trend.sql
@@ -54,7 +54,7 @@ col javexec_time_s_1exec for 9999999.999
 col buffer_gets_1exec for 999999999999.999
 col disk_reads_1exec for 999999999999.999
 col direct_writes_1exec for 999999999999.999
-select to_char(trunc(sysdate-&days_history+1)+trunc((cast(hs.begin_interval_time as date)-(trunc(sysdate-&days_history+1)))*24/(&interval_hours))*(&interval_hours)/24,'dd.mm.yyyy hh24:mi:ss') time,
+select to_char(trunc(sysdate-&days_history+1)+trunc((cast(hs.begin_interval_time as date)-(trunc(sysdate-&days_history+1)))*24/(&interval_hours))*(&interval_hours)/24,'yyyy-mm-dd hh24:mi:ss') time,
     nvl(sum(hss.executions_delta),0) executions,
     round(sum(hss.elapsed_time_delta)/1000000,3) elapsed_time_s_total,
     round(sum(hss.elapsed_time_delta)/1000000/decode(sum(hss.executions_delta),0,null,sum(hss.executions_delta)),3) elapsed_time_s_1exec,

--- a/SQL/AWR/awr_sqlid_perf_trend_by_plan.sql
+++ b/SQL/AWR/awr_sqlid_perf_trend_by_plan.sql
@@ -29,7 +29,7 @@ col disk_reads for 999999999999.999
 col direct_writes for 999999999999.999
 BREAK ON inst SKIP 1
 select hss.instance_number inst,
-    to_char(trunc(sysdate-&days_history+1)+trunc((cast(hs.begin_interval_time as date)-(trunc(sysdate-&days_history+1)))*24/(&interval_hours))*(&interval_hours)/24,'dd.mm.yyyy hh24:mi:ss') time,
+    to_char(trunc(sysdate-&days_history+1)+trunc((cast(hs.begin_interval_time as date)-(trunc(sysdate-&days_history+1)))*24/(&interval_hours))*(&interval_hours)/24,'yyyy-dd-mm hh24:mi:ss') time,
     plan_hash_value,
     sum(hss.executions_delta) executions,
     round(sum(hss.elapsed_time_delta)/1000000,3) elapsed_time_s,

--- a/SQL/AWR/awr_sqlid_perf_trend_by_plan.sql
+++ b/SQL/AWR/awr_sqlid_perf_trend_by_plan.sql
@@ -29,7 +29,7 @@ col disk_reads for 999999999999.999
 col direct_writes for 999999999999.999
 BREAK ON inst SKIP 1
 select hss.instance_number inst,
-    to_char(trunc(sysdate-&days_history+1)+trunc((cast(hs.begin_interval_time as date)-(trunc(sysdate-&days_history+1)))*24/(&interval_hours))*(&interval_hours)/24,'yyyy-dd-mm hh24:mi:ss') time,
+    to_char(trunc(sysdate-&days_history+1)+trunc((cast(hs.begin_interval_time as date)-(trunc(sysdate-&days_history+1)))*24/(&interval_hours))*(&interval_hours)/24,'yyyy-mm-dd hh24:mi:ss') time,
     plan_hash_value,
     sum(hss.executions_delta) executions,
     round(sum(hss.elapsed_time_delta)/1000000,3) elapsed_time_s,


### PR DESCRIPTION
Once you go ISO 8601 any other date format just looks wrong :)
BTW obviously you are welcome to ignore this pull request , I'm just getting a feel for git/github process.
I use  awr_sqlid_perf_trend pretty much every day, it's very useful, thanks